### PR TITLE
Corrected spelling of "micro:bit" and GiggleBot, and added plurals

### DIFF
--- a/_locales/giggle-jsdoc-strings.json
+++ b/_locales/giggle-jsdoc-strings.json
@@ -11,8 +11,8 @@
   "lights.smileShowGraph|param|graph_value": "the value to be displayed; eg: 1",
   "lights.whichEye": "Lets you use the blocks in the neopixel category for better control over the eyes.",
   "remote.onRemoteControl": "Use this block on the GiggleBot to control it with a second micro:bit",
-  "remote.remoteControl": "Use this block to turn a second Micro:bit into a remote controller.\nEasiest approach is to put this block inside a \"Forever\" block.\nYou will need to use the \"remote receiver mode\" block on the GiggleBot itself.",
+  "remote.remoteControl": "Use this block to turn a second micro:bit into a remote controller.\nEasiest approach is to put this block inside a \"Forever\" block.\nYou will need to use the \"remote receiver mode\" block on the GiggleBot itself.",
   "remote.remoteControlAction": "Put this block inside of the 'remotely controlled gigglebot' to follow all comands received via remote control.",
-  "remote.setGroup": "In order to have a remote micro:bit control the GiggleBot, both of them\nmust be in the same radio group - or remote group. You can use either this\nblock or the \"radio set group\" block found under Radio. \nThe two blocks are the same thing.\nMake sure your set of remote microbit and gigglebot is assigned a unique\ngroup, especially if there are many gigglebot pairs around you.",
+  "remote.setGroup": "In order to have a remote micro:bit control the GiggleBot, both of them\nmust be in the same radio group - or remote group. You can use either this\nblock or the \"radio set group\" block found under Radio. \nThe two blocks are the same thing.\nMake sure your set of remote microbits and GiggleBots is assigned a unique\ngroup, especially if there are many GiggleBot pairs around you.",
   "remote.setGroup|param|id": "eg: 1"
 }

--- a/giggle.ts
+++ b/giggle.ts
@@ -58,11 +58,6 @@ namespace lights {
         eyeNeopixelRight.setPixelColor(0, eyeColorRight)
         eyeNeopixelBoth.show()
 }
-    //% blockId="gigglebot_eyes" block="Light the GiggleBot's eyes"
-    //% weight=100
-    export function show_eyes() {
-        lights.whichEye(gigglebotWhichEye.Both).showColor(neopixel.colors(NeoPixelColors.Red))
-}
     /**
      * Lets you use the blocks in the neopixel category for better control over the eyes.
      */
@@ -70,7 +65,6 @@ namespace lights {
     //% group=variables
     //% weight=50
     export function whichEye(which: gigglebotWhichEye): neopixel.Strip {
-
         if (which == gigglebotWhichEye.Left)
             return eyeNeopixelLeft
         else if (which == gigglebotWhichEye.Right)

--- a/giggle.ts
+++ b/giggle.ts
@@ -63,7 +63,7 @@ namespace lights {
      */
     //% blockId="gigglebot_eye" block="%which"
     //% group=variables
-    //% weight=50
+    //% weight=100
     export function whichEye(which: gigglebotWhichEye): neopixel.Strip {
 
         if (which == gigglebotWhichEye.Left)

--- a/giggle.ts
+++ b/giggle.ts
@@ -58,12 +58,17 @@ namespace lights {
         eyeNeopixelRight.setPixelColor(0, eyeColorRight)
         eyeNeopixelBoth.show()
 }
+    //% blockId="gigglebot_eyes" block="Light the GiggleBot's eyes"
+    //% weight=100
+    export function show_eyes() {
+        lights.whichEye(gigglebotWhichEye.Both).showColor(neopixel.colors(NeoPixelColors.Red))
+}
     /**
      * Lets you use the blocks in the neopixel category for better control over the eyes.
      */
     //% blockId="gigglebot_eye" block="%which"
     //% group=variables
-    //% weight=100
+    //% weight=50
     export function whichEye(which: gigglebotWhichEye): neopixel.Strip {
 
         if (which == gigglebotWhichEye.Left)


### PR DESCRIPTION
Ref issue #26 
1.  micro:bit should not be capitalized.
2. Groups of *micro:bits" and "GiggleBots" added necessary plural spelling.